### PR TITLE
Add classifier training with live display

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project demonstrates a minimal pipeline for controlling a moving tunnel stimulus using EEG data. It consists of three components:
 
-1. **EEG Classifier** (`eeg_classifier`): reads EEG data from an LSL stream (or generates random data if none is available) and classifies each sample as either `speed_up` or `slow_down`.
+1. **EEG Classifier** (`eeg_classifier`): reads EEG data from an LSL stream (or generates random data if none is available) and classifies each sample as either `speed_up` or `slow_down`. The classifier can be trained on recorded data using the provided helper functions.
 2. **Control Interface** (`interface`): converts classifier commands into a numerical speed value.
 
 3. **Tunnel Display** (`tunnel_display`): shows an OpenGL tunnel stimulus from
@@ -17,4 +17,12 @@ python run_all.py
 `run_all.py` launches the three modules as separate processes and passes data between them using multiprocessing queues.
 
 Press `q` in the tunnel window to exit the demo.
+
+## Training the classifier
+
+Run `collect_training_data()` from `eeg_classifier.classifier` to record labeled
+EEG samples. Afterwards call `train_classifier()` to create a `model.joblib`
+file. When present, this model is loaded automatically by `run_classifier`. If
+`run_all.py` is executed, classifier decisions will be displayed in a small
+window in real time.
 

--- a/eeg_classifier/classifier.py
+++ b/eeg_classifier/classifier.py
@@ -1,5 +1,67 @@
 import time
+import os
 import numpy as np
+import cv2
+from joblib import dump, load
+from sklearn.linear_model import LogisticRegression
+
+
+def collect_training_data(out_path="training_data.npz", n_samples=100):
+    """Interactively collect training data from an EEG stream.
+
+    Users label each sample as ``speed_up`` or ``slow_down`` by
+    typing ``u`` or ``d``. If no LSL stream is available, random data is used.
+    """
+    inlet = None
+    if LSL_AVAILABLE:
+        try:
+            print("Looking for an EEG stream...")
+            streams = resolve_stream('type', 'EEG')
+            inlet = StreamInlet(streams[0])
+            print("EEG stream found")
+        except Exception as exc:
+            print(f"Could not connect to EEG stream ({exc}), using simulated data")
+            inlet = None
+    else:
+        print("pylsl not available, using simulated data")
+
+    rng = np.random.default_rng()
+    samples = []
+    labels = []
+
+    print("Collecting training data. Press 'u' for speed_up, 'd' for slow_down.")
+    for _ in range(n_samples):
+        if inlet is not None:
+            sample, _ = inlet.pull_sample(timeout=1.0)
+            if sample is None:
+                continue
+            value = np.mean(sample)
+        else:
+            value = rng.random()
+
+        label = input("Label [u/d]: ")
+        label = 1 if label.lower().startswith('u') else 0
+        samples.append([value])
+        labels.append(label)
+
+    np.savez(out_path, samples=np.array(samples), labels=np.array(labels))
+    print(f"Saved training data to {out_path}")
+
+
+def train_classifier(data_path="training_data.npz", model_path="model.joblib"):
+    """Train a simple logistic regression model on collected data."""
+    if not os.path.exists(data_path):
+        raise FileNotFoundError(data_path)
+
+    data = np.load(data_path)
+    X = data["samples"]
+    y = data["labels"]
+
+    model = LogisticRegression()
+    model.fit(X, y)
+    dump(model, model_path)
+    print(f"Model saved to {model_path}")
+
 try:
     from pylsl import StreamInlet, resolve_stream
     LSL_AVAILABLE = True
@@ -7,7 +69,7 @@ except Exception:
     LSL_AVAILABLE = False
 
 
-def run_classifier(out_queue):
+def run_classifier(out_queue, model_path="model.joblib", visualize=False):
     """Continuously read EEG data, classify, and send commands.
 
     Parameters
@@ -28,18 +90,39 @@ def run_classifier(out_queue):
     else:
         print("pylsl not available, using simulated data")
 
+    model = load(model_path) if os.path.exists(model_path) else None
     threshold = 0.5
     rng = np.random.default_rng()
+    if visualize:
+        cv2.namedWindow('Classifier', cv2.WINDOW_NORMAL)
+        display = np.zeros((100, 300, 3), dtype=np.uint8)
 
-    while True:
-        if inlet is not None:
-            sample, _ = inlet.pull_sample(timeout=1.0)
-            if sample is None:
-                continue
-            value = np.mean(sample)
-        else:
-            value = rng.random()
+    try:
+        while True:
+            if inlet is not None:
+                sample, _ = inlet.pull_sample(timeout=1.0)
+                if sample is None:
+                    continue
+                value = np.mean(sample)
+            else:
+                value = rng.random()
 
-        command = 'speed_up' if value > threshold else 'slow_down'
-        out_queue.put(command)
-        time.sleep(0.1)
+            if model is not None:
+                pred = model.predict([[value]])[0]
+                command = 'speed_up' if pred == 1 else 'slow_down'
+            else:
+                command = 'speed_up' if value > threshold else 'slow_down'
+
+            if visualize:
+                display[:] = 0
+                color = (0, 255, 0) if command == 'speed_up' else (0, 0, 255)
+                cv2.putText(display, command, (10, 60),
+                            cv2.FONT_HERSHEY_SIMPLEX, 1.5, color, 2)
+                cv2.imshow('Classifier', display)
+                cv2.waitKey(1)
+
+            out_queue.put(command)
+            time.sleep(0.1)
+    finally:
+        if visualize:
+            cv2.destroyAllWindows()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ pylsl
 pygame
 moderngl
 pyopengl
+joblib
+opencv-python

--- a/run_all.py
+++ b/run_all.py
@@ -6,6 +6,6 @@ from tunnel_display.run_display import run_display
 if __name__ == "__main__":
     classifier_queue = Queue()
     speed_queue = Queue()
-    Process(target=run_classifier, args=(classifier_queue,)).start()
+    Process(target=run_classifier, args=(classifier_queue,), kwargs={'visualize': True}).start()
     Process(target=run_interface, args=(classifier_queue, speed_queue)).start()
     Process(target=run_display, args=(speed_queue,)).start()


### PR DESCRIPTION
## Summary
- allow real-time visualisation of classifier output
- support collecting and training a simple classifier
- integrate new live display in `run_all.py`
- document the training workflow
- add missing dependencies

## Testing
- `python -m py_compile eeg_classifier/classifier.py interface/control_interface.py tunnel_display/run_display.py run_all.py`


------
https://chatgpt.com/codex/tasks/task_e_687deb88949c832b91623e9971d31e60