### PR TITLE
Add console fallback for classifier window

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ file. When present, this model is loaded automatically by `run_classifier`. If
 `run_all.py` is executed, classifier decisions will be displayed in a small
 window in real time.
 
+If OpenCV cannot create GUI windows (e.g. on a headless server), the
+classifier falls back to printing the decisions in the terminal so you can
+still observe the output.
+

--- a/eeg_classifier/classifier.py
+++ b/eeg_classifier/classifier.py
@@ -93,9 +93,16 @@ def run_classifier(out_queue, model_path="model.joblib", visualize=False):
     model = load(model_path) if os.path.exists(model_path) else None
     threshold = 0.5
     rng = np.random.default_rng()
+    use_cv2 = False
+    use_console = False
     if visualize:
-        cv2.namedWindow('Classifier', cv2.WINDOW_NORMAL)
-        display = np.zeros((100, 300, 3), dtype=np.uint8)
+        try:
+            cv2.namedWindow('Classifier', cv2.WINDOW_NORMAL)
+            display = np.zeros((100, 300, 3), dtype=np.uint8)
+            use_cv2 = True
+        except cv2.error as e:
+            print("cv2.namedWindow failed, falling back to console output.")
+            use_console = True
 
     try:
         while True:
@@ -113,16 +120,23 @@ def run_classifier(out_queue, model_path="model.joblib", visualize=False):
             else:
                 command = 'speed_up' if value > threshold else 'slow_down'
 
-            if visualize:
+            if use_cv2:
                 display[:] = 0
                 color = (0, 255, 0) if command == 'speed_up' else (0, 0, 255)
                 cv2.putText(display, command, (10, 60),
                             cv2.FONT_HERSHEY_SIMPLEX, 1.5, color, 2)
                 cv2.imshow('Classifier', display)
                 cv2.waitKey(1)
+            elif use_console:
+                color_code = '\033[92m' if command == 'speed_up' else '\033[91m'
+                reset = '\033[0m'
+                print(f"{color_code}{command}{reset}")
 
             out_queue.put(command)
             time.sleep(0.1)
     finally:
-        if visualize:
-            cv2.destroyAllWindows()
+        if use_cv2:
+            try:
+                cv2.destroyAllWindows()
+            except cv2.error as e:
+                print("cv2.destroyAllWindows failed:", e)


### PR DESCRIPTION
## Summary
- handle failed GUI initialization in `run_classifier`
- print classifier decisions in the terminal when OpenCV GUI isn't available
- document the fallback mechanism in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687dfcda1454832bae13220828b8d965