### PR TITLE
Handle cv2 errors in classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ file. When present, this model is loaded automatically by `run_classifier`. If
 `run_all.py` is executed, classifier decisions will be displayed in a small
 window in real time.
 
-If OpenCV cannot create GUI windows (e.g. on a headless server), the
-classifier falls back to printing the decisions in the terminal so you can
+If OpenCV cannot create or display GUI windows (e.g. on a headless server),
+the classifier falls back to printing the decisions in the terminal so you can
 still observe the output.
 

--- a/eeg_classifier/classifier.py
+++ b/eeg_classifier/classifier.py
@@ -125,8 +125,13 @@ def run_classifier(out_queue, model_path="model.joblib", visualize=False):
                 color = (0, 255, 0) if command == 'speed_up' else (0, 0, 255)
                 cv2.putText(display, command, (10, 60),
                             cv2.FONT_HERSHEY_SIMPLEX, 1.5, color, 2)
-                cv2.imshow('Classifier', display)
-                cv2.waitKey(1)
+                try:
+                    cv2.imshow('Classifier', display)
+                    cv2.waitKey(1)
+                except cv2.error:
+                    print("cv2.imshow failed, falling back to console output.")
+                    use_cv2 = False
+                    use_console = True
             elif use_console:
                 color_code = '\033[92m' if command == 'speed_up' else '\033[91m'
                 reset = '\033[0m'


### PR DESCRIPTION
## Summary
- handle `cv2.imshow` errors by falling back to console output
- clarify fallback description in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_687e05383bac832ba4db67514339aee2