### PR TITLE
Add matplotlib close in run_display

### DIFF
--- a/tunnel_display/run_display.py
+++ b/tunnel_display/run_display.py
@@ -48,7 +48,10 @@ def run_display(speed_queue):
                     show_frame_matplotlib(frame)
     finally:
         renderer.release()
-        if not use_matplotlib:
+        if use_matplotlib:
+            plt.close()
+            plt.ioff()
+        else:
             try:
                 cv2.destroyAllWindows()
             except cv2.error as e:


### PR DESCRIPTION
## Summary
- ensure matplotlib window closes when using the fallback display

## Testing
- `python -m py_compile tunnel_display/run_display.py`

------
https://chatgpt.com/codex/tasks/task_e_687e0db36ccc832b9f51e58b22fc02b8